### PR TITLE
Fall back to example array mock data if spec provides one.

### DIFF
--- a/lib/mock/query-collection.js
+++ b/lib/mock/query-collection.js
@@ -36,7 +36,11 @@ function queryCollection(req, res, next, dataStore) {
         resources = _.pluck(resources, 'data');
       }
       else {
-        // There is no data, so use the current date/time as the "last-modified" header
+        // There is no data, check for an example and, if present, use that
+        if (res.swagger.schema && res.swagger.schema.items.example) {
+          resources.push(res.swagger.schema.items.example);
+        }
+        // Use the current date/time as the last-modified header
         res.swagger.lastModified = new Date();
       }
 


### PR DESCRIPTION
This is just a proof of concept that demonstrates serving up an example array item if the schema provides one.

Note: this will fill in any nested objects in the schema example, but will NOT recursively fill in nested arrays.  If anyone knows where to look to enable that, please let me know.

You could imagine controlling this more explicitly with an 'x-auto-generate' property, for example...

Seeking feedback.