### PR TITLE
Prune `basePath` when creating Resources based on `request.path`

### DIFF
--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -295,5 +295,10 @@ var util = module.exports = {
 
       return schema;
     }
+  },
+
+    normalizeRequestPath: function(path, swagger) {
+        var base = swagger.api.basePath;
+        return path.substr(base.length);
   }
 };

--- a/lib/mock/edit-collection.js
+++ b/lib/mock/edit-collection.js
@@ -32,7 +32,7 @@ var _          = require('lodash'),
  * @param   {DataStore} dataStore
  */
 function mergeCollection(req, res, next, dataStore) {
-  var collection = req.path;
+  var collection = util.normalizeRequestPath(req.path, req.swagger);
   var resources = createResources(req);
 
   // Set the "Location" HTTP header.
@@ -65,7 +65,7 @@ function mergeCollection(req, res, next, dataStore) {
  * @param   {DataStore} dataStore
  */
 function overwriteCollection(req, res, next, dataStore) {
-  var collection = req.path;
+  var collection = util.normalizeRequestPath(req.path, req.swagger);
   var resources = createResources(req);
 
   // Set the "Location" HTTP header.
@@ -129,7 +129,8 @@ function createResources(req) {
     resourceName = encodeURIComponent(resourceName);
 
     // Create a REST resource
-    var resource = new Resource(req.path, resourceName, data);
+    var reqPath = util.normalizeRequestPath(req.path, req.swagger);
+    var resource = new Resource(reqPath, resourceName, data);
     resources.push(resource);
   }
 
@@ -352,7 +353,8 @@ function sendResponse(req, res, next, dataStore) {
     }
     else {
       // Response body is the entire collection (new, edited, and old)
-      dataStore.getCollection(req.path, function(err, collection) {
+      var reqPath = util.normalizeRequestPath(req.path, req.swagger);
+      dataStore.getCollection(reqPath, function(err, collection) {
         res.body = _.pluck(collection, 'data');
         next(err);
       });

--- a/lib/mock/edit-resource.js
+++ b/lib/mock/edit-resource.js
@@ -83,7 +83,8 @@ function deleteResource(req, res, next, dataStore) { // jshint ignore:line
  * @returns {Resource}
  */
 function createResource(req) {
-  var resource = new Resource(req.path);
+  var reqPath = util.normalizeRequestPath(req.path, req.swagger);
+  var resource = new Resource(reqPath);
 
   if (!_.isEmpty(req.files)) {
     // Save file data too

--- a/lib/mock/query-collection.js
+++ b/lib/mock/query-collection.js
@@ -24,7 +24,8 @@ var _    = require('lodash'),
  * @param   {DataStore} dataStore
  */
 function queryCollection(req, res, next, dataStore) {
-  dataStore.getCollection(req.path, function(err, resources) {
+  var reqPath = util.normalizeRequestPath(req.path, req.swagger);
+  dataStore.getCollection(reqPath, function(err, resources) {
     if (!err) {
       resources = filter(resources, req);
 
@@ -62,7 +63,8 @@ function queryCollection(req, res, next, dataStore) {
  * @param   {DataStore} dataStore
  */
 function deleteCollection(req, res, next, dataStore) {
-  dataStore.getCollection(req.path, function(err, resources) {
+  var reqPath = util.normalizeRequestPath(req.path, req.swagger);
+  dataStore.getCollection(reqPath, function(err, resources) {
     if (err) {
       next(err);
     }
@@ -75,7 +77,7 @@ function deleteCollection(req, res, next, dataStore) {
       }
       else if (resourcesToDelete.length === resources.length) {
         // Delete the whole collection
-        dataStore.deleteCollection(req.path, sendResponse);
+        dataStore.deleteCollection(reqPath, sendResponse);
       }
       else {
         // Only delete the matching resources

--- a/lib/mock/query-resource.js
+++ b/lib/mock/query-resource.js
@@ -19,7 +19,8 @@ var util     = require('../helpers/util'),
  * @param   {DataStore} dataStore
  */
 function queryResource(req, res, next, dataStore) {
-  var resource = new Resource(req.path);
+  var reqPath = util.normalizeRequestPath(req.path, req.swagger);
+  var resource = new Resource(reqPath);
 
   dataStore.get(resource, function(err, result) {
     if (err) {


### PR DESCRIPTION
Potential fix for #13. An additional helper function seemed like the most elegant way to solve the problem, but I'm not sure what the preferred style or architecture is for this project. It works fine in my light manual testing; obviously I did not add any formal tests for it.