### PR TITLE
Handle `file` being a string in mock sendFile

### DIFF
--- a/lib/mock/index.js
+++ b/lib/mock/index.js
@@ -274,6 +274,15 @@ function sendFile(req, res, next, file) {
     return;
   }
 
+  if (typeof file === 'string' || file instanceof String) {
+    setContentType(req, res, ['application/octet-stream', '*/*']);
+
+    // `file` is the file's contents as as string
+    util.debug('Sending raw string data');
+    res.send(file);
+    return;
+  }
+
   // `file` is a file info object
   fs.exists(file.path || '', function(exists) {
     if (exists) {


### PR DESCRIPTION
See https://github.com/BigstickCarpet/swagger-express-middleware/issues/100